### PR TITLE
Remove extract and related telegram handlers

### DIFF
--- a/bot/handler/extract/extract_cmd.py
+++ b/bot/handler/extract/extract_cmd.py
@@ -1,67 +1,15 @@
 from aiogram.types import Message, BufferedInputFile
-from scrap.jobs.statistic import get_attribute_value, find_element_value, get_max, get_min, get_mean
-from scrap.jobs.fetch_ads import fetch_description_ads
+from scrap.jobs.statistic import (
+    get_attribute_value,
+    find_element_value,
+    get_max,
+    get_min,
+    get_mean,
+)
 import json
 import os
-from collections import Counter, defaultdict
 import io
 
-async def extract_cmd(message: Message):
-    if not message.text:
-        await message.reply("Usage : /extract <attribute|element> <clé> [index]")
-        return
-    try:
-        parts = message.text.split(maxsplit=3)
-        if len(parts) == 4:
-            _, mode, param, index = parts
-            index = int(index)
-        else:
-            _, mode, param = parts
-            index = None
-    except ValueError:
-        await message.reply("Usage : /extract <attribute|element> <clé> [index]")
-        return
-    data_dir = os.path.join("scrap", "tools", "scrap", "data")
-    if not os.path.exists(data_dir):
-        await message.reply("Aucune donnée à extraire. Lancez d'abord /search.")
-        return
-    results = []
-    for file in os.listdir(data_dir):
-        if file.startswith("ads_") and file.endswith(".json"):
-            file_path = os.path.join(data_dir, file)
-            with open(file_path, encoding="utf-8") as f:
-                data = json.load(f)
-            if mode == "attribute":
-                res = get_attribute_value(data, param, index)
-            elif mode == "element":
-                res = find_element_value(data, param, index)
-            else:
-                await message.reply("Mode inconnu. Utilisez 'attribute' ou 'element'.")
-                return
-            results.append({file: res})
-    if not results:
-        await message.reply("Aucun fichier ads_<nbr>.json trouvé.")
-        return
-    # On limite la taille du message pour Telegram
-    msg = json.dumps(results, ensure_ascii=False)
-    if len(msg) > 4000:
-        msg = msg[:3990] + "... (résultat tronqué)"
-    await message.reply(f"Résultat : {msg}")
-
-async def extract_description_cmd(message: Message):
-    if not message.text:
-        await message.reply("Usage : /description <url_annonce>")
-        return
-    try:
-        _, url = message.text.split(maxsplit=1)
-    except ValueError:
-        await message.reply("Usage : /description <url_annonce>")
-        return
-    try:
-        description = fetch_description_ads(url)
-        await message.reply(f"Description : {description}")
-    except Exception as e:
-        await message.reply(f"Erreur lors de la récupération : {e}")
 
 async def list_attributes_elements_cmd(message: Message):
     data_dir = os.path.join("scrap", "tools", "scrap", "data")
@@ -103,36 +51,6 @@ async def list_attributes_elements_cmd(message: Message):
         msg = msg[:3990] + "... (résultat tronqué)"
     await message.reply(msg, parse_mode="HTML")
 
-async def list_attributes_cmd(message: Message):
-    data_dir = os.path.join("scrap", "tools", "scrap", "data")
-    if not os.path.exists(data_dir):
-        await message.reply("Aucune donnée à analyser. Lancez d'abord /search.")
-        return
-    attribute_set = set()
-    for file in os.listdir(data_dir):
-        if file.startswith("ads_") and file.endswith(".json"):
-            file_path = os.path.join(data_dir, file)
-            with open(file_path, encoding="utf-8") as f:
-                try:
-                    data = json.load(f)
-                except Exception:
-                    continue
-                if isinstance(data, list):
-                    for ad in data:
-                        if isinstance(ad, dict) and "attributes" in ad and isinstance(ad["attributes"], list):
-                            for attr in ad["attributes"]:
-                                if isinstance(attr, dict) and "key" in attr:
-                                    attribute_set.add(attr["key"])
-                elif isinstance(data, dict) and "attributes" in data and isinstance(data["attributes"], list):
-                    for attr in data["attributes"]:
-                        if isinstance(attr, dict) and "key" in attr:
-                            attribute_set.add(attr["key"])
-    msg = "<b>Attributes trouvés :</b>\n"
-    for k in sorted(attribute_set):
-        msg += f"- {k}\n"
-    if len(msg) > 4000:
-        msg = msg[:3990] + "... (résultat tronqué)"
-    await message.reply(msg, parse_mode="HTML")
 
 async def list_elements_cmd(message: Message):
     data_dir = os.path.join("scrap", "tools", "scrap", "data")

--- a/bot/handler/init.py
+++ b/bot/handler/init.py
@@ -2,7 +2,13 @@ from bot.handler.start import start_cmd
 from bot.handler.help import help_cmd
 from aiogram.filters import Command
 from bot.handler.search.search_cmd import search_cmd
-from bot.handler.extract.extract_cmd import extract_cmd, extract_description_cmd, list_attributes_elements_cmd, list_attributes_cmd, list_elements_cmd, max_cmd, min_cmd, mean_cmd
+from bot.handler.extract.extract_cmd import (
+    list_attributes_elements_cmd,
+    list_elements_cmd,
+    max_cmd,
+    min_cmd,
+    mean_cmd,
+)
 from bot.handler.filter.filter_cmd import filter_cmd, stats_cmd, chart_cmd
 from bot.handler.export.export_cmd import export_cmd, export_callback, export_json_cmd, export_csv_cmd, export_excel_cmd, export_stats_cmd
 from bot.handler.cleanup_cmd import cleanup_cmd, cleanup_status_cmd
@@ -59,10 +65,7 @@ def register_handlers(dp):
     dp.message.register(help_cmd, Command("help"))
     dp.callback_query.register(help_callback, lambda c: c.data == "show_help")
     dp.message.register(search_cmd, Command("search"))
-    dp.message.register(extract_cmd, Command("extract"))
-    dp.message.register(extract_description_cmd, Command("description"))
     dp.message.register(list_attributes_elements_cmd, Command("list"))
-    dp.message.register(list_attributes_cmd, Command("list_attributes"))
     dp.message.register(list_elements_cmd, Command("list_elements"))
     dp.message.register(max_cmd, Command("max"))
     dp.message.register(min_cmd, Command("min"))


### PR DESCRIPTION
## Summary
- drop `/extract`, `/description`, and `/list_attributes` handlers
- unregister removed commands in Telegram bot router

## Testing
- `python -m py_compile bot/handler/extract/extract_cmd.py bot/handler/init.py`

------
https://chatgpt.com/codex/tasks/task_e_687a9322f8f88333be3894235d7250e9